### PR TITLE
Refactor model structure for LLMPrompt

### DIFF
--- a/models/load.go
+++ b/models/load.go
@@ -8,14 +8,14 @@ import (
 func (wrapper ModelWrapper) LoadStreamingModel(modelName string, prompt string) (*bedrockruntime.InvokeModelWithResponseStreamOutput, error) {
 	switch modelName {
 	case llama3:
-		llama := Llama{bedrock: wrapper, prompt: prompt}
+		llama := Llama{LLMPrompt{wrapper, prompt}}
 		response, err := llama.Stream()
 		if err != nil {
 			return nil, err
 		}
 		return response, nil
 	case anthropic:
-		anth := Anthropic{bedrock: wrapper, prompt: prompt}
+		anth := Anthropic{LLMPrompt{wrapper, prompt}}
 		response, err := anth.Stream()
 		if err != nil {
 			return nil, err
@@ -29,14 +29,14 @@ func (wrapper ModelWrapper) LoadStreamingModel(modelName string, prompt string) 
 func (wrapper ModelWrapper) LoadModel(modelName string, prompt string) (string, error) {
 	switch modelName {
 	case llama3:
-		llama := Llama{bedrock: wrapper, prompt: prompt}
+		llama := Llama{LLMPrompt{wrapper, prompt}}
 		response, err := llama.Invoke()
 		if err != nil {
 			return "", err
 		}
 		return response, nil
 	case anthropic:
-		anth := Anthropic{bedrock: wrapper, prompt: prompt}
+		anth := Anthropic{LLMPrompt{wrapper, prompt}}
 		response, err := anth.Invoke()
 		if err != nil {
 			return "", err

--- a/models/types.go
+++ b/models/types.go
@@ -14,14 +14,17 @@ type LLM interface {
 	Stream() (*bedrockruntime.InvokeModelWithResponseStreamOutput, error)
 }
 
-type Llama struct {
+type LLMPrompt struct {
 	bedrock ModelWrapper
 	prompt  string
 }
 
+type Llama struct {
+	LLMPrompt
+}
+
 type Anthropic struct {
-	bedrock ModelWrapper
-	prompt  string
+	LLMPrompt
 }
 
 type StreamingOutputHandler func(ctx context.Context, part []byte) error


### PR DESCRIPTION
This commit refactors the code structure of the `Llama` and `Anthropic` types in the model. It extracts the `ModelWrapper` and `prompt` fields from these types and encapsulates them into a new type named `LLMPrompt`. This change ultimately improves code clarity and modularity.