### PR TITLE
Refactor return type and add WebSocket connection test

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -37,7 +37,7 @@ func (m MLWrapper) executeModel(w http.ResponseWriter, r *http.Request) {
 				return nil
 			}
 
-			_, err = models.CallStreamingOutputFunction(modelName, aiResponse, processFunc)
+			err = models.CallStreamingOutputFunction(modelName, aiResponse, processFunc)
 			if err != nil {
 				log.Fatal("streaming output processing error: ", err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/gorilla/websocket"
+	"log"
+	"net/url"
+	"testing"
+)
+
+const (
+	testWebSocketURL = "ws://localhost:8080/ws/model"
+)
+
+func TestWebSocketConnection(t *testing.T) {
+	// Create WebSocket URL with query parameters
+	u, err := url.Parse(testWebSocketURL)
+	if err != nil {
+		t.Fatalf("Failed to parse WebSocket base URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("model", "llama3")
+	u.RawQuery = q.Encode()
+
+	// Dial the WebSocket server
+	client, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatalf("Failed to dial WebSocket server: %v", err)
+	}
+	defer client.Close()
+
+	message := "Tell me something about yourself in 20 words."
+	if err := client.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	_, receivedMessage, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("Failed to receive message: %v", err)
+	}
+	log.Printf("Received message: %s", string(receivedMessage))
+	if len(string(receivedMessage)) <= 0 {
+		t.Error("Received empty message")
+	}
+}

--- a/models/common.go
+++ b/models/common.go
@@ -12,20 +12,20 @@ const (
 	claudeV3ModelID = "anthropic.claude-3-haiku-20240307-v1:0"
 )
 
-func CallStreamingOutputFunction(llm string, output *bedrockruntime.InvokeModelWithResponseStreamOutput, handler StreamingOutputHandler) (interface{}, error) {
+func CallStreamingOutputFunction(llm string, output *bedrockruntime.InvokeModelWithResponseStreamOutput, handler StreamingOutputHandler) error {
 	switch llm {
 	case llama3:
 		err := ProcessLlamaStreamingOutput(output, handler)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	case anthropic:
 		err := ProcessAnthropicStreamingOutput(output, handler)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	default:
-		return nil, fmt.Errorf("unknown llm value: %s", llm)
+		return fmt.Errorf("unknown llm value: %s", llm)
 	}
-	return nil, nil
+	return nil
 }


### PR DESCRIPTION
Refactored the return type of `CallStreamingOutputFunction` to eliminate redundant nil returns. Added a new test for WebSocket connection to ensure proper communication with the model server. Adjusted the related usage in controller to match the updated function signature.